### PR TITLE
feat: 재사용 가능한 api 설정

### DIFF
--- a/src/apis/client/APIClient.ts
+++ b/src/apis/client/APIClient.ts
@@ -1,0 +1,64 @@
+import BASE_URL from "./baseUrl";
+
+const baseHeader = {
+  "Content-Type": "application/json",
+};
+
+type HTTPMethod = "GET" | "POST" | "PATCH" | "DELETE";
+
+interface RequestConfig {
+  method: HTTPMethod;
+  headers?: Record<string, string>;
+  body?: any;
+}
+
+async function apiRequest<T = any>(
+  path: string,
+  config: RequestConfig,
+): Promise<T> {
+  const url = `${BASE_URL}/${path}`;
+  const response = await fetch(url, {
+    method: config.method,
+    headers: config.headers,
+    body:
+      config.body instanceof FormData
+        ? config.body
+        : config.body
+          ? JSON.stringify(config.body)
+          : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `${config.method} 요청에서 에러가 발생했습니다. (url: ${url})`,
+    );
+  }
+
+  return response.json();
+}
+
+export const apiClient = {
+  get: <T>(path: string) => apiRequest<T>(path, { method: "GET" }),
+
+  post: <T>(path: string, body: any) => {
+    const headers = body instanceof FormData ? undefined : baseHeader;
+    return apiRequest<T>(path, {
+      method: "POST",
+      headers,
+      body,
+    });
+  },
+
+  patch: <T>(path: string, body?: any) => {
+    return apiRequest<T>(path, {
+      method: "PATCH",
+      body,
+    });
+  },
+
+  delete: <T>(path: string, body?: any) =>
+    apiRequest<T>(path, {
+      method: "DELETE",
+      body,
+    }),
+};

--- a/src/apis/client/baseUrl.ts
+++ b/src/apis/client/baseUrl.ts
@@ -1,0 +1,6 @@
+const BASE_URL =
+  process.env.NEXT_PUBLIC_API_MOCKING === "enabled"
+    ? "http://localhost:9090"
+    : "";
+
+export default BASE_URL;

--- a/src/apis/constants/https.ts
+++ b/src/apis/constants/https.ts
@@ -1,0 +1,28 @@
+export const HTTP_STATUS_CODE = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500,
+} as const;
+
+export const HTTP_ERROR_MESSAGE = {
+  [HTTP_STATUS_CODE.NOT_FOUND]: {
+    HEADING: "페이지를 찾을 수 없습니다.",
+    BODY: "페이지가 존재하지 않거나 삭제되어 찾을 수 없어요.",
+    BUTTON: "홈으로 가기",
+  },
+  [HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR]: {
+    HEADING: "현재 페이지를 표시할 수 없습니다.",
+    BODY: `잠시 후 다시 시도해주세요.`,
+    BUTTON: "새로고침",
+  },
+  [HTTP_STATUS_CODE.BAD_REQUEST]: {
+    HEADING: "잘못된 요청입니다.",
+    BODY: "확인 후 다시 시도해주세요.",
+    BUTTON: "홈으로 가기",
+  },
+} as const;

--- a/src/apis/constants/routes.ts
+++ b/src/apis/constants/routes.ts
@@ -1,0 +1,9 @@
+const API_ROUTES = {
+  test: "/test",
+} as const;
+
+export const pathGenerator = {
+  test: (url: string) => `${API_ROUTES.test}/${url}`,
+};
+
+export default API_ROUTES;

--- a/src/apis/error/HTTPError.ts
+++ b/src/apis/error/HTTPError.ts
@@ -1,0 +1,23 @@
+export interface HTTPErrorInfo {
+  message?: string;
+  payload: {
+    HEADING: string;
+    BODY: string;
+    BUTTON: string;
+  };
+}
+
+class HTTPError extends Error {
+  statusCode: number;
+  information: HTTPErrorInfo;
+
+  constructor(statusCode: number, errorInfo: HTTPErrorInfo) {
+    super(errorInfo.message ?? errorInfo.payload.HEADING);
+
+    this.name = "HTTPError";
+    this.statusCode = statusCode;
+    this.information = errorInfo;
+  }
+}
+
+export default HTTPError;

--- a/src/apis/services/test.ts
+++ b/src/apis/services/test.ts
@@ -1,0 +1,3 @@
+import { apiClient } from "../client/APIClient";
+
+export const getTest = () => apiClient.get("/test");

--- a/src/apis/utils/handleAPIError.ts
+++ b/src/apis/utils/handleAPIError.ts
@@ -1,0 +1,26 @@
+import { HTTP_ERROR_MESSAGE, HTTP_STATUS_CODE } from "../constants/https";
+import HTTPError from "../error/HTTPError";
+
+const handleAPIError = (responseStatus: number, message?: string) => {
+  const errorPayload =
+    HTTP_ERROR_MESSAGE[responseStatus as keyof typeof HTTP_ERROR_MESSAGE];
+
+  if (errorPayload) {
+    throw new HTTPError(responseStatus, {
+      message: message || `HTTP 오류: ${responseStatus}`,
+      payload: errorPayload,
+    });
+  } else if (responseStatus >= HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR) {
+    throw new HTTPError(HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR, {
+      message: message || "서버 오류가 발생했습니다.",
+      payload: HTTP_ERROR_MESSAGE[HTTP_STATUS_CODE.INTERNAL_SERVER_ERROR],
+    });
+  } else if (responseStatus >= HTTP_STATUS_CODE.BAD_REQUEST) {
+    throw new HTTPError(HTTP_STATUS_CODE.BAD_REQUEST, {
+      message: message || "잘못된 요청입니다.",
+      payload: HTTP_ERROR_MESSAGE[HTTP_STATUS_CODE.BAD_REQUEST],
+    });
+  }
+};
+
+export default handleAPIError;

--- a/src/constants/pageRoutes.ts
+++ b/src/constants/pageRoutes.ts
@@ -1,0 +1,5 @@
+const PAGE_ROUTES = {
+  main: "/",
+};
+
+export default PAGE_ROUTES;


### PR DESCRIPTION
- 재사용 가능한 fetch api 설정 -> 토큰을 사용하게 된다면 추가 수정이 필요합니다.
- 공통 에러처리를 위한 에러 클래스, 핸들러 함수 구현
- status code와 에러 메세지 생성
- base url 임시 설정 -> 추후 endpoint에 맞게 수정해야 합니다.